### PR TITLE
Kill ffmpeg

### DIFF
--- a/addons/script.bt.transcode/addon.py
+++ b/addons/script.bt.transcode/addon.py
@@ -46,6 +46,11 @@ def getMoviePathFromUpnpPath(inputFile) :
         if  os.path.basename(urllib.unquote(inputFile)) == os.path.basename(filename) :
             return filename
 
+def killFfmpeg() :
+    pid = readPidFromFile()
+    if pid :
+        kill(pid)
+
 def cleanUpFiles(playlistFile) :
     basename, extension = os.path.splitext(playlistFile)
     for f in os.listdir(__encodingdir__):
@@ -56,9 +61,7 @@ def cleanUpFiles(playlistFile) :
                 xbmc.log("%s: Failed to remove %s: %s" % (__addonname__, f, traceback.format_exc()), xbmc.LOGDEBUG)
 
 def cleanUpServer(playlistFile) :
-    pid = readPidFromFile()
-    if pid :
-        kill(pid)
+    killFfmpeg()
     xbmc.log("%s: cleanup files for %s" % (__addonname__, playlistFile), xbmc.LOGDEBUG)
     for i in xrange(10) :
         cleanUpFiles(playlistFile)
@@ -109,5 +112,7 @@ if __name__ == '__main__':
         writePidToFile(pid)
     elif 'stream_cleanup' == mode :
         cleanUpServer(destination)
+    elif 'download_cleanup' == mode :
+        killFfmpeg()
     else :
         xbmc.log('%s: Unknown mode "%s"' % (__addonname__, mode), xbmc.LOGERROR)

--- a/addons/script.bt.transcode/addon.py
+++ b/addons/script.bt.transcode/addon.py
@@ -61,7 +61,6 @@ def cleanUpFiles(playlistFile) :
                 xbmc.log("%s: Failed to remove %s: %s" % (__addonname__, f, traceback.format_exc()), xbmc.LOGDEBUG)
 
 def cleanUpServer(playlistFile) :
-    killFfmpeg()
     xbmc.log("%s: cleanup files for %s" % (__addonname__, playlistFile), xbmc.LOGDEBUG)
     for i in xrange(10) :
         cleanUpFiles(playlistFile)
@@ -111,6 +110,7 @@ if __name__ == '__main__':
         pid = run([__ffmpeg__] + movieTranscodeForStreaming(getMoviePathFromUpnpPath(inputFile), destination))
         writePidToFile(pid)
     elif 'stream_cleanup' == mode :
+        killFfmpeg()
         cleanUpServer(destination)
     elif 'download_cleanup' == mode :
         killFfmpeg()

--- a/addons/script.bt.transcode/sys_nt.py
+++ b/addons/script.bt.transcode/sys_nt.py
@@ -17,7 +17,6 @@ def run(command) :
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         process = subprocess.Popen(command, startupinfo=startupinfo)
-        process.wait()
         xbmc.log("%s: run returned %s" % (__addonname__, process.returncode), xbmc.LOGDEBUG)
     except:
         xbmc.log("%s: Failed to execute %s: %s" % (__addonname__, " ".join(command), traceback.format_exc()), xbmc.LOGDEBUG)
@@ -26,7 +25,8 @@ def run(command) :
 def kill(pid) :
     xbmc.log('%s: kill ffmpeg pid %s' % (__addonname__, pid), xbmc.LOGDEBUG)
     try:
-        os.system('taskkill /f /t /pid %s' % pid)
+        command = ['taskkill', '/F', '/T', '/PID', pid]
+        run(command)
     except:
         xbmc.log('%s: Failed to kill pid %s: %s' % (__addonname__, pid, traceback.format_exc()), xbmc.LOGDEBUG)
 

--- a/addons/script.bt.transcode/sys_nt.py
+++ b/addons/script.bt.transcode/sys_nt.py
@@ -14,8 +14,10 @@ __addonpath__ = __addon__.getAddonInfo('path')
 def run(command) :
     xbmc.log('%s: run \"%s\"' % (__addonname__, ' '.join(command)), xbmc.LOGDEBUG)
     try:
-        process = subprocess.Popen(command, stderr=subprocess.STDOUT)
-        # process.wait()
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        process = subprocess.Popen(command, startupinfo=startupinfo)
+        process.wait()
         xbmc.log("%s: run returned %s" % (__addonname__, process.returncode), xbmc.LOGDEBUG)
     except:
         xbmc.log("%s: Failed to execute %s: %s" % (__addonname__, " ".join(command), traceback.format_exc()), xbmc.LOGDEBUG)

--- a/addons/script.bt.transcode/sys_posix.py
+++ b/addons/script.bt.transcode/sys_posix.py
@@ -19,7 +19,6 @@ def run(command) :
     xbmc.log('%s: run \"%s\"' % (__addonname__, ' '.join(command)), xbmc.LOGDEBUG)
     try:
         process = subprocess.Popen(command, stderr=subprocess.STDOUT)
-        process.wait()
         xbmc.log('%s: run returned %s' % (__addonname__, process.returncode), xbmc.LOGDEBUG)
     except:
         xbmc.log('%s: Failed to execute %s: %s' % (__addonname__, ' '.join(command), traceback.format_exc()), xbmc.LOGDEBUG)


### PR DESCRIPTION
removes process.wait() from the call to ffmpeg. this was causing a 
problem w/ the timing of the write/read of the pid