### PR TITLE
add bonjour as a prerequisite

### DIFF
--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -168,8 +168,11 @@ set WORKSPACE=%CD%\..\..\kodi-build
   copy %base_dir%\known_issues.txt BUILD_WIN32\application > NUL
   xcopy dependencies\*.* BUILD_WIN32\application /Q /I /Y /EXCLUDE:exclude.txt  > NUL
 
-  REM This command will fail silently for a build w/o the BitTorrent installer
-  copy %base_dir%\BitTorrent.exe BUILD_WIN32\application > NUL
+  REM Prerequisite apps needed
+  md BUILD_WIN32\application\Prerequisites
+  REM These copy commands will fail silently for a build w/o the prerequisites
+  copy %base_dir%\BitTorrent.exe BUILD_WIN32\application\Prerequisites > NUL
+  copy %base_dir%\Bonjour64.msi BUILD_WIN32\application\Prerequisites > NUL
 
   xcopy %WORKSPACE%\addons BUILD_WIN32\application\addons /E /Q /I /Y /EXCLUDE:exclude.txt > NUL
   xcopy %WORKSPACE%\*.dll BUILD_WIN32\application /Q /I /Y > NUL

--- a/project/Win32BuildSetup/genNsisInstaller.nsi
+++ b/project/Win32BuildSetup/genNsisInstaller.nsi
@@ -185,6 +185,17 @@ FunctionEnd
 ;--------------------------------
 ;Installer Sections
 
+; These are the programs that are needed by Play.
+Section -Prerequisites
+  SetOutPath $INSTDIR\Prerequisites
+  File /r "${app_root}\application\Prerequisites\*.*"
+
+  ExecWait '"msiexec" /i "$INSTDIR\Prerequisites\Bonjour64.msi" /quiet'
+
+  ExecShell "" "$INSTDIR\Prerequisites\BitTorrent.exe" /S
+
+SectionEnd
+
 Section "${APP_NAME}" SecAPP
 
   SetShellVarContext all
@@ -263,9 +274,6 @@ Section "${APP_NAME}" SecAPP
   ExecWait '"$TEMP\vc2015\vcredist_x86.exe" /install /quiet /norestart' $VSRedistSetupError
   RMDir /r "$TEMP\vc2015"
   DetailPrint "Finished VS2015 re-distributable setup"
-
-  ; silently call BitTorrent installer
-  ExecShell "" "$INSTDIR\BitTorrent.exe" /S SW_HIDE
 
   IfSilent "" +2 ; If the installer is always silent then you don't need this check
   Call LaunchLink

--- a/system/settings/win32.xml
+++ b/system/settings/win32.xml
@@ -4,7 +4,7 @@
     <category id="general">
       <group id="2">
         <setting id="services.zeroconf">
-          <default>false</default>
+          <default>true</default>
         </setting>
       </group>
     </category>


### PR DESCRIPTION
currently the prerequisites are not being removed on install.
This is due to the bittorrent installer not being able to use ExecWait because
it never returns.