### PR TITLE
Remove service.xbmc.versioncheck from being included in the build.

### DIFF
--- a/project/cmake/installdata/common/addons.txt
+++ b/project/cmake/installdata/common/addons.txt
@@ -39,7 +39,6 @@ addons/resource.images.weathericons.default/*
 addons/service.bt.autosources/*
 addons/service.bt.play/*
 addons/service.libraryautoupdate/*
-addons/service.xbmc.versioncheck/*
 addons/metadata.local/*
 addons/metadata.album.universal/*
 addons/metadata.artists.universal/*

--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -32,7 +32,6 @@
   <addon>service.bt.autosources</addon>
   <addon>service.bt.play</addon>
   <addon>service.libraryautoupdate</addon>
-  <addon>service.xbmc.versioncheck</addon>
   <addon>skin.estuary</addon>
   <addon>skin.estouchy</addon>
   <addon>skin.bt.play</addon>


### PR DESCRIPTION
Removed service.xbmc.versioncheck from being placed in the build